### PR TITLE
Wrong exception was thrown if an exception occurred in a test.

### DIFF
--- a/Automoqer.Test/AutoMoqerTest.cs
+++ b/Automoqer.Test/AutoMoqerTest.cs
@@ -57,5 +57,42 @@ namespace Automoqer.Test
         {
             var automoqer = new AutoMoqer<ServiceWithNoPublicConstructor>();
         }
+
+		[TestMethod]
+		public void AutoMoqerThrowsExceptionOnDisposeForNonCalledMethods()
+		{
+			try
+			{
+				using(var automoqer = new AutoMoqer<CommonService>())
+				{
+					automoqer
+						.Param<ISimpleService>()
+						.Setup(f => f.GetBool())
+						.Returns(true);
+				}
+
+				// Should not happen.
+				Assert.IsFalse(true);
+			}
+			catch(System.Reflection.TargetInvocationException exc)
+			{
+				// Moq.MockVerificationException is internal.
+				Assert.AreEqual("Moq.MockVerificationException", exc.InnerException.GetType().FullName);
+			}
+		}
+
+		[TestMethod]
+		[ExpectedException(typeof(ArgumentException))]
+		public void AutoMoqerShouldThrowCorrectExceptionWithUsingStatement()
+		{
+			using(var automoqer = new AutoMoqer<CommonService>())
+			{
+				automoqer
+					.Param<ISimpleService>()
+					.Setup(f => f.SetString(It.IsAny<string>()));
+
+				throw new ArgumentException();
+			}
+		}
     }
 }

--- a/Automoqer/Automoqer.cs
+++ b/Automoqer/Automoqer.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;
+using System.Runtime.InteropServices;
 using Moq;
 
 namespace Automoqer
@@ -60,7 +61,15 @@ namespace Automoqer
 
         public void Dispose()
         {
-            foreach (var parameter in _parameters)
+			var exceptionOccurred = Marshal.GetExceptionPointers() != IntPtr.Zero
+						|| Marshal.GetExceptionCode() != 0;
+
+			if(exceptionOccurred)
+			{
+				return;
+			}
+
+			foreach (var parameter in _parameters)
             {
                 var method = parameter.GetType().GetMethod("VerifyAll");
                 method.Invoke(parameter, null);


### PR DESCRIPTION
If you are using AutoMoqer in a using statement there is an issue with what exception is reported to the test runner. Since the dispose method runs VerifyAll, a Moq.MockVerificationException is thrown instead of the exception that occurred in the test. This hides the real exception and makes it hard to find out what went wrong.

I added two tests to this PR together with the fix for the issue:
* AutoMoqerThrowsExceptionOnDisposeForNonCalledMethods - This test should work also in 1.0.2
* AutoMoqerShouldThrowCorrectExceptionWithUsingStatement - This test fails in 1.0.2